### PR TITLE
fix(minilm): run inference off platform UI thread

### DIFF
--- a/android/src/main/kotlin/com/telosnex/fonnx/FonnxPlugin.kt
+++ b/android/src/main/kotlin/com/telosnex/fonnx/FonnxPlugin.kt
@@ -71,8 +71,18 @@ class FonnxPlugin : FlutterPlugin, MethodCallHandler {
 
                 val miniLm = cachedMiniLm
                 if (miniLm != null) {
-                    val embedding = miniLm.getEmbedding(wordpieces.map { it.toLong() }.toLongArray())
-                    result.success(embedding.first())
+                    launch(Dispatchers.Default) {
+                        try {
+                            val embedding = miniLm.getEmbedding(wordpieces.map { it.toLong() }.toLongArray())
+                            launch(Dispatchers.Main) {
+                                result.success(embedding.first())
+                            }
+                        } catch (e: Throwable) {
+                            launch(Dispatchers.Main) {
+                                result.error("MiniLm", "Inference failed: ${e.message}", null)
+                            }
+                        }
+                    }
                 } else {
                     result.error("MiniLm", "Could not instantiate model", null)
                 }

--- a/ios/Classes/FonnxPlugin.swift
+++ b/ios/Classes/FonnxPlugin.swift
@@ -109,17 +109,21 @@ public class FonnxPlugin: NSObject, FlutterPlugin {
       return
     }
 
-    model.getEmbedding(
-      tokens: tokens,
-      completion: { (answer, error) in
-        if let error = error {
-          result(
-            FlutterError(code: "MiniLm", message: "Failed to get embedding", details: error)
-          )
-        } else {
-          result(answer)
-        }
-      })
+    DispatchQueue.global(qos: .userInitiated).async {
+      model.getEmbedding(
+        tokens: tokens,
+        completion: { (answer, error) in
+          DispatchQueue.main.async {
+            if let error = error {
+              result(
+                FlutterError(code: "MiniLm", message: "Failed to get embedding", details: error)
+              )
+            } else {
+              result(answer)
+            }
+          }
+        })
+    }
   }
 
   public func doPyannote(_ call: FlutterMethodCall, result: @escaping FlutterResult) {


### PR DESCRIPTION
MiniLM inference ran on the platform main/UI thread on Android (Dispatchers.Main) and iOS (synchronous session.run on the channel thread), causing frame drops during embedding. Dispatch to a background thread and post the result back on the main thread, matching the existing whisper/pyannote handlers.